### PR TITLE
feat: transform dataset distributions

### DIFF
--- a/02_transform/extract_methods/__init__.py
+++ b/02_transform/extract_methods/__init__.py
@@ -2,3 +2,4 @@ from .title import entityTitle
 from .description import entityDescription
 from .landing_page import entityLandingPage
 from .timestamp import dateFromTimestamp
+from .distribution import datasetDistributions

--- a/02_transform/extract_methods/distribution.py
+++ b/02_transform/extract_methods/distribution.py
@@ -1,0 +1,109 @@
+import json
+from pathlib import Path
+from .description import entityDescription
+from .utils import isEnOrNb
+
+def datasetDistributions(entity_id):
+    distributions = []
+    title_file = open('../tmp/extract/data/' + entity_id + '/field_data_field_distribution.json')
+    title_field = json.load(title_file)
+
+    for index in title_field['field_distribution_target_id']:
+        dist_id = str(title_field['field_distribution_target_id'][index])
+        if Path('../tmp/extract/distribution/' + dist_id).exists():
+            distribution = {}
+            distribution['title'] = distributionTitle(dist_id)
+            distribution['description'] = distributionDescription(dist_id)
+            distribution['downloadURL'] = distributionDownloadUrl(dist_id)
+            distribution['accessURL'] = distributionAccessUrl(dist_id)
+            distribution['license'] = distributionLicense(dist_id)
+            distribution['format'] = distributionFormat(dist_id)
+
+            distributions.append(distribution)
+    
+    return distributions
+
+def distributionTitle(entity_id):
+    title = {}
+    title_file = open('../tmp/extract/distribution/' + entity_id + '/field_data_field_distribution_title.json')
+    title_field = json.load(title_file)
+
+    titles = title_field['field_distribution_title_value']
+
+    if len(titles) == 1 and not isEnOrNb(title_field['language']['0']):
+        title['nb'] = titles['0']
+    else:
+        for index in titles:
+            lang = title_field['language'][index]
+            if(isEnOrNb(lang)):
+                title[lang] = titles[index]
+    
+    return title
+
+def distributionDescription(entity_id):
+    description = {}
+    description_file = open('../tmp/extract/distribution/' + entity_id + '/field_data_field_description.json')
+    description_field = json.load(description_file)
+
+    descriptions = description_field['field_description_value']
+
+    if len(descriptions) == 1 and not isEnOrNb(description_field['language']['0']):
+        description['nb'] = descriptions['0']
+    else:
+        for index in descriptions:
+            lang = description_field['language'][index]
+            if(isEnOrNb(lang)):
+                description[lang] = descriptions[index]
+    
+    return description
+
+def distributionAccessUrl(entity_id):
+    urls = []
+    json_file = open('../tmp/extract/distribution/' + entity_id + '/field_data_field_access_url.json')
+    field = json.load(json_file)
+
+    for index in field['field_access_url_url']:
+        urls.append(field['field_access_url_url'][index])
+
+    return urls
+
+def distributionDownloadUrl(entity_id):
+    urls = []
+    json_file = open('../tmp/extract/distribution/' + entity_id + '/field_data_field_download_url.json')
+    field = json.load(json_file)
+
+    for index in field['field_download_url_url']:
+        urls.append(field['field_download_url_url'][index])
+
+    return urls
+
+def distributionLicense(entity_id):
+    value = None
+    json_file = open('../tmp/extract/distribution/' + entity_id + '/field_data_field_license.json')
+    field = json.load(json_file)
+
+    license_id = field['field_license_target_id'].get('0')
+
+    if license_id is not None:
+        license_file = open('../tmp/extract/licens/' + str(license_id) + '/field_data_field_url.json')
+        license_field = json.load(license_file)
+
+        value = {}
+        value['uri'] = license_field['field_url_url'].get('0')
+
+    return value
+
+def distributionFormat(entity_id):
+    formats = []
+    json_file = open('../tmp/extract/distribution/' + entity_id + '/field_data_field_format.json')
+    field = json.load(json_file)
+
+    for index in field['field_format_target_id']:
+        format_id = str(field['field_format_target_id'][index])
+        if Path('../tmp/extract/format/' + format_id).exists():
+            format_file = open('../tmp/extract/format/' + format_id + '/field_data_field_key.json')
+            format_field = json.load(format_file)
+
+            formats.append(format_field['field_key_value'].get('0'))
+
+    return formats

--- a/02_transform/transform_datasets.py
+++ b/02_transform/transform_datasets.py
@@ -1,7 +1,13 @@
 import json
 from pathlib import Path
 
-from extract_methods import entityTitle, entityDescription, entityLandingPage, dateFromTimestamp
+from extract_methods import (
+    entityTitle,
+    entityDescription,
+    entityLandingPage,
+    dateFromTimestamp,
+    datasetDistributions
+)
 
 f = open('../tmp/extract/data.json')
 datasets = json.load(f)
@@ -16,6 +22,7 @@ for dataset_index in datasets['nid']:
     fdk_dataset['landingPage'] = entityLandingPage(ds_id)
     fdk_dataset['issued'] = dateFromTimestamp(datasets['created'][dataset_index])
     fdk_dataset['modified'] = dateFromTimestamp(datasets['changed'][dataset_index])
+    fdk_dataset['distribution'] = datasetDistributions(ds_id)
 
     # Save dataset to file
     with open('../tmp/transform/dataset/' + ds_id + '.json', 'w') as outfile:


### PR DESCRIPTION
![Screenshot from 2020-05-05 09-25-36](https://user-images.githubusercontent.com/50194012/81044391-88e22180-8eb4-11ea-9b05-c1d121a8498a.png)

```{
    "title": {
        "nb": "Leveranser til kornkjøper eller såvareforretning i landbruket i kornåret juli 2018 til juni 2019"
    },
    "description": {
        "nb": "Dette er datasett som viser leveranser av korn eller såkorn som er levert fra jordbruksforetak til kornkjøper eller såvareforretning i landbruket. For det enkelte foretak vises organisasjonsnummer, navn, kommunenummer og kilo som er levert i leveranseåret som er fra juli i produksjonsåret til juni året etter. Dataene inkluderer ikke leiemalt korn eller leierenset såvare. Nytt datasett blir lagt ut årlig. Dette skjer vanligvis i oktober, året etter at leveransene har funnet sted."
    },
    "distribution": [
        {
            "title": {},
            "description": {
                "nb": "REST-API i formatene XML, JSON(P), CSV og YAML, og komplett nedlasting i CSV."
            },
            "downloadURL": [
                "https://hotell.difi.no/download/ldir/leveransedata-korn/2018-2019?download"
            ],
            "accessURL": [
                "https://hotell.difi.no/?dataset=ldir/leveransedata-korn/2018-2019"
            ],
            "license": {
                "uri": "http://data.norge.no/nlod/"
            },
            "format": [
                "CSV",
                "JSON",
                "JSONP",
                "XML",
                "YAML"
            ]
        }
    ]
}```